### PR TITLE
Fix sensor.h dependency issue

### DIFF
--- a/components/ble_client_hid/__init__.py
+++ b/components/ble_client_hid/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import CONF_ID
 
 
 DEPENDENCIES = ['ble_client']
+AUTO_LOAD = ["sensor", "text_sensor"]
 CODE_OWNERS=["@fsievers22"]
 
 MULTI_CONF=3


### PR DESCRIPTION
When you try to compile the project it is not including `sensor.h` file requested in `ble_client_hid.cpp`:

```
In file included from src/esphome/components/ble_client_hid/ble_client_hid.cpp:1:
src/esphome/components/ble_client_hid/ble_client_hid.h:4:10: fatal error: esphome/components/sensor/sensor.h: No such file or directory
 #include "esphome/components/sensor/sensor.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
*** [.pioenvs\backpack-light\src\esphome\components\ble_client_hid\ble_client_hid.o] Error 1
```

Use [AUTO_LOAD](https://esphome.io/guides/contributing.html#extras) to specify witch components sources should be included in output directory.