### PR TITLE
optional api integration

### DIFF
--- a/components/ble_client_hid/__init__.py
+++ b/components/ble_client_hid/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import CONF_ID
 
 
 DEPENDENCIES = ['ble_client']
+AUTO_LOAD = ["sensor", "text_sensor"]
 CODE_OWNERS=["@fsievers22"]
 
 MULTI_CONF=3

--- a/components/ble_client_hid/ble_client_hid.cpp
+++ b/components/ble_client_hid/ble_client_hid.cpp
@@ -197,7 +197,9 @@ void BLEClientHID::send_input_report_event(esp_ble_gattc_cb_param_t *p_data){
     } else {
       usage = std::to_string(value.usage.page) + "_" + std::to_string(value.usage.usage);
     }
+    #ifdef USE_API
     this->fire_homeassistant_event("esphome.hid_events", {{"usage", usage}, {"value", std::to_string(value.value)}});
+    #endif
     if(this->last_event_usage_text_sensor != nullptr){
       this->last_event_usage_text_sensor->publish_state(usage);
     }

--- a/components/ble_client_hid/ble_client_hid.h
+++ b/components/ble_client_hid/ble_client_hid.h
@@ -1,8 +1,12 @@
+#include <map>
 #include "esphome/core/component.h"
 #include "esphome/components/ble_client/ble_client.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#ifdef USE_API
 #include "esphome/components/api/custom_api_device.h"
+#endif
 #include "hid_parser.h"
 
 #ifdef USE_ESP32
@@ -53,7 +57,11 @@ class GATTReadData {
     uint16_t handle_;
 };
 
+#ifdef USE_API
 class BLEClientHID : public Component, public api::CustomAPIDevice, public ble_client::BLEClientNode {
+#else
+class BLEClientHID : public Component, public ble_client::BLEClientNode {
+#endif
  public:
   void loop() override;
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,


### PR DESCRIPTION
This PR eliminates need to include `api` integration in configuration. Could be useful for standalone projects where there is not need to send event to Home Assistant.