### PR TITLE
Fix incorrect multiple-count report field sizing

### DIFF
--- a/components/ble_client_hid/hid_parser.cpp
+++ b/components/ble_client_hid/hid_parser.cpp
@@ -335,7 +335,7 @@ namespace esphome
     void HIDInputReport::push_back(HIDInputReportItem *item)
     {
       this->items.push_back(item);
-      this->report_size += item->report_size;
+      this->report_size += item->get_total_size();
     }
 
     std::vector<HIDReportItemValue> HIDReportMap::parse(uint8_t *hid_report_data)
@@ -368,6 +368,11 @@ namespace esphome
         }
       }
       return report_values;
+    }
+
+    size_t HIDInputReportItem::get_total_size()
+    {
+      return this->report_size * this->report_count;
     }
 
     int32_t HIDInputReportItem::parse_input_report_item(uint8_t *report_data, uint16_t bit_offset, uint16_t report_size, HIDLogicalRange logical_range)

--- a/components/ble_client_hid/hid_parser.h
+++ b/components/ble_client_hid/hid_parser.h
@@ -91,6 +91,7 @@ namespace esphome
       {
         delete usage_collection;
       };
+      size_t get_total_size();
       virtual std::vector<HIDReportItemValue> parse(uint8_t *hid_report_data) = 0;
       static int32_t parse_input_report_item(uint8_t *report_data, uint16_t bit_offset, uint16_t report_size, HIDLogicalRange logical_range);
       const uint8_t report_size; // in bits


### PR DESCRIPTION
When enumerating a device's report fields, the resulting `HIDInputReportItem` is instantiated with a count and the size of an individual field. The total size of the item is the field size times the number of fields associated with this item, but `HIDInputReport::push_back()`, which is used to give instantiated report items their offset in the report's buffer, uses only the individual field's size.

The effect of this is that the offset for every `HIDInputReportItem` is incorrect (too low) after the first item that has a count greater than one. This PR is a simple fix to give `HIDInputReportItem` a public member to provide its total size to `HIDInputReport` so that correct offsets can be calculated.