### PR TITLE
Update text_sensor.py

### DIFF
--- a/components/ble_client_hid/text_sensor.py
+++ b/components/ble_client_hid/text_sensor.py
@@ -10,8 +10,13 @@ TextSensor = text_sensor.text_sensor_ns.class_(
     "TextSensor"
 )
 
+# Updated: Fixed deprecation warning by replacing text_sensor.TEXT_SENSOR_SCHEMA
+# with text_sensor.text_sensor_schema(TextSensor) to comply with ESPHome 2025.11.0 changes
+# Reference: https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/
 CONFIG_SCHEMA = cv.All(
-    text_sensor.TEXT_SENSOR_SCHEMA.extend(
+    text_sensor.text_sensor_schema(
+        TextSensor
+    ).extend(
         {
             cv.GenerateID(): cv.declare_id(TextSensor)
         }


### PR DESCRIPTION
 Fixed deprecation warning by replacing text_sensor.TEXT_SENSOR_SCHEMA
# with text_sensor.text_sensor_schema(TextSensor) to comply with ESPHome 2025.11.0 changes # Reference: https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/