### PR TITLE
Include the Mac Address in the esphome.hid_events

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The event is named `esphome.hid_events` and contains the usage as a string and t
 Example:
 ```yaml
 data:
+  mac: "FF:FF:20:00:0F:15"
   usage: "KEYBOARD_EXAMPLE"
   value: 1
 ```

--- a/components/ble_client_hid/ble_client_hid.cpp
+++ b/components/ble_client_hid/ble_client_hid.cpp
@@ -246,8 +246,8 @@ void BLEClientHID::send_input_report_event(esp_ble_gattc_cb_param_t *p_data) {
               std::to_string(value.usage.usage);
     }
     #ifdef USE_API
-    this->fire_homeassistant_event("esphome.hid_events", {{"usage", usage}, {"value", std::to_string(value.value)}});
-    ESP_LOGD(TAG, "Send HID event to HomeAssistant: usage: %s, value: %d", usage.c_str(), value.value);
+    this->fire_homeassistant_event("esphome.hid_events", {{"mac", this->parent()->address_str()}, {"usage", usage}, {"value", std::to_string(value.value)}});
+    ESP_LOGD(TAG, "Send HID event to HomeAssistant: mac: %s, usage: %s, value: %d", this->parent()->address_str(), usage.c_str(), value.value);
     #endif
     if(this->last_event_usage_text_sensor != nullptr){
       this->last_event_usage_text_sensor->publish_state(usage);
@@ -260,8 +260,8 @@ void BLEClientHID::send_input_report_event(esp_ble_gattc_cb_param_t *p_data) {
     if (this->last_event_value_sensor != nullptr) {
       this->last_event_value_sensor->publish_state(value.value);
     }
-    ESP_LOGI(TAG, "Send HID event to HomeAssistant: usage: %s, value: %d",
-             usage.c_str(), value.value);
+    ESP_LOGI(TAG, "Send HID event to HomeAssistant: mac: %s, usage: %s, value: %d",
+             this->parent()->address_str(), usage.c_str(), value.value);
   }
 
   delete[] data;


### PR DESCRIPTION
Include the Mac Address in the "esphome.hid_events" to identify the origin of the event for multiple devices.

Example event:

data:
.  mac: "FF:FF:20:00:0F:15"
.  usage: "KEYBOARD_EXAMPLE"
.  value: 1
